### PR TITLE
Exclude pig dependencies from jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,10 +132,16 @@ project(':lipstick-console') {
             println "building jar without Pig"
             compile('org.apache.pig:pig:0.11.1') {
                 exclude module: 'hsqld'
+                exclude module: 'jetty'
+                exclude module: 'jsp-api-2.1'
+                exclude module: 'servlet-api-2.5'
             }
         } else {
             includeInJar('org.apache.pig:pig:0.11.1') {
                 exclude module: 'hsqld'
+                exclude module: 'jetty'
+                exclude module: 'jsp-api-2.1'
+                exclude module: 'servlet-api-2.5'
             }
         }
 


### PR DESCRIPTION
When Pig is included in the lipstick-console jar tomcat won't load the jar causing an error:

```
Caused by: org.hibernate.MappingException: Unable to load class [ com.netflix.lipstick.model.P2jCounters] declared in Hibernate configuration <mapping/> entry
        at org.hibernate.cfg.Configuration.parseMappingElement(Configuration.java:2369)
        at org.hibernate.cfg.Configuration.parseSessionFactory(Configuration.java:2310)
        at org.hibernate.cfg.Configuration.doConfigure(Configuration.java:2290)
        at org.hibernate.cfg.Configuration.doConfigure(Configuration.java:2243)
        at org.hibernate.cfg.Configuration.configure(Configuration.java:2194)
        at org.springframework.orm.hibernate3.LocalSessionFactoryBean.buildSessionFactory(LocalSessionFactoryBean.java:642)
        at org.springframework.orm.hibernate3.AbstractSessionFactoryBean.afterPropertiesSet(AbstractSessionFactoryBean.java:188)
        at org.codehaus.groovy.grails.orm.hibernate.ConfigurableLocalSessionFactoryBean.afterPropertiesSet(ConfigurableLocalSessionFactoryBean.java:176)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1514)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1452)
        ... 61 more
Caused by: java.lang.ClassNotFoundException: com.netflix.lipstick.model.P2jCounters
        at java.lang.Class.forName(Class.java:188)
```

Which is a result of Tomcat rejecting the jar because the Servlet class gets included.
