### PR TITLE
display schema on union in graph if it results in a schema change

### DIFF
--- a/lipstick-console/src/main/java/com/netflix/lipstick/Pig2DotGenerator.java
+++ b/lipstick-console/src/main/java/com/netflix/lipstick/Pig2DotGenerator.java
@@ -143,7 +143,7 @@ public class Pig2DotGenerator {
                         }
                     }
                 } catch (ParserException e) {
-                    e.printStackTrace();
+                    LOG.warn("Error comparing operator predecessors: ", e);
                     return false;
                 }
             }


### PR DESCRIPTION
If the aliases being unioned have differing schemas  we should display the schema on the union operator in the Lipstick graph.
