### PR TITLE
Allow for custom error hanlding via ppnl error handling interface

### DIFF
--- a/lipstick-console/src/main/java/com/netflix/lipstick/listeners/LipstickPPNL.java
+++ b/lipstick-console/src/main/java/com/netflix/lipstick/listeners/LipstickPPNL.java
@@ -52,12 +52,17 @@ public class LipstickPPNL implements PigProgressNotificationListener {
     protected LipstickPigServer ps;
     protected PigContext context;
     protected List<P2LClient> clients = Lists.newLinkedList();
+    protected List<PPNLErrorHandler> errorHandlers = Lists.newLinkedList();
 
     /**
      * Initialize a new LipstickPPNL object.
      */
     public LipstickPPNL() {
         LOG.info("--- Init TBPPNL ---");
+    }
+
+    public void addErrorHandler(PPNLErrorHandler errHandler) {
+        errorHandlers.add(errHandler);
     }
 
     /**
@@ -123,6 +128,9 @@ public class LipstickPPNL implements PigProgressNotificationListener {
             }
         } catch (Exception e) {
             LOG.error("Caught unexpected exception", e);
+            for (PPNLErrorHandler errHandler : errorHandlers) {
+                errHandler.handlePlanGeneratorsError(e);
+            }
         }
     }
 
@@ -144,6 +152,9 @@ public class LipstickPPNL implements PigProgressNotificationListener {
             }
         } catch (Exception e) {
             LOG.error("Caught unexpected exception", e);
+            for (PPNLErrorHandler errHandler : errorHandlers) {
+                errHandler.handleInitialPlanNotificationError(e);
+            }
         }
     }
 
@@ -183,6 +194,9 @@ public class LipstickPPNL implements PigProgressNotificationListener {
             }
         } catch (Exception e) {
             LOG.error("Caught unexpected exception", e);
+            for (PPNLErrorHandler errHandler : errorHandlers) {
+                errHandler.handleJobStartedNotificationError(e);
+            }
         }
     }
 
@@ -203,6 +217,9 @@ public class LipstickPPNL implements PigProgressNotificationListener {
             }
         } catch (Exception e) {
             LOG.error("Caught unexpected exception", e);
+            for (PPNLErrorHandler errHandler : errorHandlers) {
+                errHandler.handleJobFinishedNotificationError(e);
+            }
         }
     }
 
@@ -223,6 +240,9 @@ public class LipstickPPNL implements PigProgressNotificationListener {
             }
         } catch (Exception e) {
             LOG.error("Caught unexpected exception", e);
+            for (PPNLErrorHandler errHandler : errorHandlers) {
+                errHandler.handleJobFailedNotificationError(e);
+            }
         }
     }
 
@@ -253,6 +273,9 @@ public class LipstickPPNL implements PigProgressNotificationListener {
             }
         } catch (Exception e) {
             LOG.error("Caught unexpected exception", e);
+            for (PPNLErrorHandler errHandler : errorHandlers) {
+                errHandler.handleProgressUpdatedNotificationError(e);
+            }
         }
     }
 
@@ -272,6 +295,9 @@ public class LipstickPPNL implements PigProgressNotificationListener {
             }
         } catch (Exception e) {
             LOG.error("Caught unexpected exception", e);
+            for (PPNLErrorHandler errHandler : errorHandlers) {
+                errHandler.handleLaunchCompletedNotificationError(e);
+            }
         }
     }
 

--- a/lipstick-console/src/main/java/com/netflix/lipstick/listeners/PPNLErrorHandler.java
+++ b/lipstick-console/src/main/java/com/netflix/lipstick/listeners/PPNLErrorHandler.java
@@ -1,0 +1,47 @@
+package com.netflix.lipstick.listeners;
+
+/**
+ * Lipstick Pig Progress notification listener Error Handler
+ *
+ * For finer grain error hanlding from the LipstickPPNL, implement
+ * this interface, then pass an instance to LipstickPPNL.addErrorHandler()
+ */
+public interface PPNLErrorHandler {
+
+    /**
+     * Called when an unhandled excepction from LipstickPPNL.setPlanGenerators() occurs
+     */
+    public void handlePlanGeneratorsError(Exception e);
+
+    /**
+     * Called when an unhandled excepction from LipstickPPNL.initialPlanNotification() occurs
+     */
+    public void handleInitialPlanNotificationError(Exception e);
+
+    /**
+     * Called when an unhandled excepction from LipstickPPNL.jobStartedNotification() occurs
+     */
+    public void handleJobStartedNotificationError(Exception e);
+
+    /**
+     * Called when an unhandled excepction from LipstickPPNL.jobFinishedNotification() occurs
+     */
+    public void handleJobFinishedNotificationError(Exception e);
+
+    /**
+     * Called when an unhandled excepction from LipstickPPNL.jobFailedNotification() occurs
+     */
+    public void handleJobFailedNotificationError(Exception e);
+
+    /**
+     * Called when an unhandled excepction from LipstickPPNL.progressUpdatedNotification() occurs
+     */
+    public void handleProgressUpdatedNotificationError(Exception e);
+
+    /**
+     * Called when an unhandled excepction from LipstickPPNL.launchCompletedNotification() occurs
+     */
+    public void handleLaunchCompletedNotificationError(Exception e);
+
+}
+


### PR DESCRIPTION
When the PPNL observes an unhandled exception it does a log.error() and continues.  For our use case\* we need a bit more control, so that errors can be martialled and forwarded to a downstream consumer.  To achieve this, this pull request adds a new error handling interface that the PPNL forwards unhandled exceptions to in addition to the existing log.error().  
- All of our errors get encoded into json and pushed to SQS where we later either show them to users or alert on if they are more systemic issues and not user error.
