### PR TITLE
example1 jar filename fix

### DIFF
--- a/quickstart/example1
+++ b/quickstart/example1
@@ -33,4 +33,4 @@ Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
 fi
 
-exec "$JAVACMD" -jar ../lipstick-console/build/libs/lipstick-console-*-full.jar -x local -propertyFile ./pig.properties ./test_local.pig
+exec "$JAVACMD" -jar ../lipstick-console/build/libs/lipstick-console-*-withHadoop.jar -x local -propertyFile ./pig.properties ./test_local.pig


### PR DESCRIPTION
Hi,

I just followed Getting Started, and found example1 won't get started.

Here's the tiny fix.

Thanks.
