### PR TITLE
option to exclude libraries from the jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,19 +124,26 @@ project(':lipstick-console') {
     }
 
     dependencies {
-         includeInJar('dk.brics.automaton:automaton:1.11-8')
-         includeInJar('org.codehaus.jackson:jackson-mapper-asl:1.9.10')
-         includeInJar('com.google.guava:guava:12.0')
-         includeInJar('org.kohsuke:graphviz-api:1.1')
-         includeInJar('org.apache.commons:commons-io:1.3.2')
-         includeInJar('log4j:log4j:1.2.17')
-         includeInJar('joda-time:joda-time:1.6')
-         includeInJar('com.googlecode.jatl:jatl:0.2.2')
-         includeInJar('com.sun.jersey:jersey-client:1.8')
-         includeInJar('com.sun.jersey:jersey-core:1.8')
-         includeInJar('jline:jline:0.9.94')
-         includeInJar('org.antlr:antlr:3.4')
-         includeInJar('org.antlr:antlr-runtime:3.4')
+         def requiredLib = { lib ->
+             if (project.hasProperty('withoutDependencies')) {
+                 compile(lib);
+             } else {
+                 includeInJar(lib);
+             }
+         }
+         requiredLib('dk.brics.automaton:automaton:1.11-8')
+         requiredLib('org.codehaus.jackson:jackson-mapper-asl:1.9.10')
+         requiredLib('com.google.guava:guava:12.0')
+         requiredLib('org.kohsuke:graphviz-api:1.1')
+         requiredLib('org.apache.commons:commons-io:1.3.2')
+         requiredLib('log4j:log4j:1.2.17')
+         requiredLib('joda-time:joda-time:1.6')
+         requiredLib('com.googlecode.jatl:jatl:0.2.2')
+         requiredLib('com.sun.jersey:jersey-client:1.8')
+         requiredLib('com.sun.jersey:jersey-core:1.8')
+         requiredLib('jline:jline:0.9.94')
+         requiredLib('org.antlr:antlr:3.4')
+         requiredLib('org.antlr:antlr-runtime:3.4')
 
          pigInJar('org.apache.pig:pig:0.11.1') {
                 exclude module: 'hsqld'


### PR DESCRIPTION
We use the lipstick-console jar in one of our project, but it uses a different version of guava.  We've found that unless we explicitly exclude it like this pull requests gives us the option to our application will use Lipstick's version of guava instead.  There had been a similar option in build.gradle before it had been refactored.
