### PR TITLE
handle null values for constantexpressions

### DIFF
--- a/lipstick-console/src/main/java/com/netflix/lipstick/adaptors/LOJsonAdaptor.java
+++ b/lipstick-console/src/main/java/com/netflix/lipstick/adaptors/LOJsonAdaptor.java
@@ -172,8 +172,16 @@ public class LOJsonAdaptor {
 
         private static String nodeToString(LogicalExpression node, LogicalExpressionPlan plan) throws FrontendException {
             if (node instanceof ConstantExpression) {
-                return ((ConstantExpression) node).getValue().toString();
+                Object value = ((ConstantExpression) node).getValue();
+                if (value != null) {
+                    return value.toString();
+                } else {
+                    // This should ONLY happen in edge cases when the constant expression is built
+                    // incorrectly, eg with the ASSERT operator in the case where there's no message
+                    return "null"; 
+                }                
             }
+            
             List<String> outList = Lists.newArrayList();
             List<Operator> s = plan.getSuccessors(node);
             if (s != null && !s.isEmpty()) {


### PR DESCRIPTION
Minor issue with ASSERT (which shouldn't even happen yet as Lipstick is intended for pig 0.11.1 which doesn't have ASSERT) where the ConstantExpression representing the failure message is null.
