### PR TITLE
Make it configurable to retrieve reducer task reports in JobWarnings

### DIFF
--- a/lipstick-console/src/main/java/com/netflix/lipstick/warnings/JobWarnings.java
+++ b/lipstick-console/src/main/java/com/netflix/lipstick/warnings/JobWarnings.java
@@ -159,13 +159,17 @@ public class JobWarnings {
     }
 
     public List<ReducerDuration> enumerateReducerRunTimesAccending(JobClient jobClient, String jobId) {
-        try {
-            TaskReport[] reduceTasks = jobClient.getReduceTaskReports(jobId);
-            return enumerateReducerRunTimesAccending(reduceTasks);
-        } catch (IOException e) {
-            log.error("Error getting reduce task reports, continuing", e);
-            return Lists.newArrayList();
+        if (!jobClient.getConf().getBoolean("pig.stats.notaskreport", false)) {
+            try {
+                TaskReport[] reduceTasks = jobClient.getReduceTaskReports(jobId);
+                return enumerateReducerRunTimesAccending(reduceTasks);
+            } catch (IOException e) {
+                log.error("Error getting reduce task reports, continuing", e);
+            }
+        } else {
+            log.info("Skipping reduce task reports for job " + jobId);
         }
+        return Lists.newArrayList();
     }
 
     /* Extract all running or completed reducer tasks for the job, their runtime and sort them


### PR DESCRIPTION
In Hadoop 2, the job history server (JHS) is not that stable. The problem is that any call to JHS can make Pig jobs get stuck if JHS is not responding. This is often an issue in production ETL flow.

So Lipstick should skip calling [Map|Reduce]TaskReports() when "pig.stats.notaskreport" is set to true.
