### PR TITLE
Lipstick shows wrong duration when job runs over days

### DIFF
--- a/lipstick-server/web-app/tossboss-main/js/tossboss-templates.js
+++ b/lipstick-server/web-app/tossboss-main/js/tossboss-templates.js
@@ -199,7 +199,7 @@ mrJobsTmpl: ' \
             <% } %> \
             <% if ((mrJobInfo.runData.startTime) && (mrJobInfo.runData.finishTime)) { %> \
               <% var duration = hhmmss(mrJobInfo.runData.finishTime - mrJobInfo.runData.startTime) %> \
-              <td><%= duration.format("HH:mm:ss") %></td> \
+              <td><%= duration %></td> \
             <% } else { %> \
               <td>--</td> \
             <% } %> \


### PR DESCRIPTION
Here is an example-

![screen shot 2014-07-28 at 2 47 41 pm 1](https://cloud.githubusercontent.com/assets/179618/3785142/0877f41c-19c0-11e4-98a7-6b396cb583fd.png)
As can be seen, the job ran over 17 hours (from 25th to 26th), but the duration shows 5 hours.

I identified the following code as culprit-
var duration = moment().startOf("day").add("ms", (mrJobInfo.runData.finishTime - mrJobInfo.runData.startTime))

This assumes that all the job starts and finishes on the same day, which cannot be always true.
