### PR TITLE
Updating warbler version to fix build failures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Netflix
+Google Inc.

--- a/lipstick-server/Gemfile
+++ b/lipstick-server/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem 'sinatra'
-gem 'warbler'
+gem 'warbler', '>= 1.4.8'
 gem 'yard'
 gem 'rack-test'

--- a/lipstick-server/Gemfile.lock
+++ b/lipstick-server/Gemfile.lock
@@ -1,32 +1,36 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    jruby-jars (1.7.16.1)
-    jruby-rack (1.1.16)
+    jruby-jars (1.7.22)
+    jruby-rack (1.1.19)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
-    rake (10.3.2)
-    rubyzip (1.1.6)
+    rake (10.4.2)
+    rubyzip (1.1.7)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     tilt (1.4.1)
-    warbler (1.4.4)
+    warbler (1.4.9)
       jruby-jars (>= 1.5.6, < 2.0)
-      jruby-rack (>= 1.0.0)
+      jruby-rack (>= 1.1.1, < 1.3)
       rake (>= 0.9.6)
       rubyzip (>= 0.9, < 1.2)
     yard (0.8.7.6)
 
 PLATFORMS
   java
+  ruby
 
 DEPENDENCIES
   rack-test
   sinatra
-  warbler
+  warbler (>= 1.4.8)
   yard
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
What:
This pull request updates warbler version in the Gemfile and Gemfile.lock to fix issues with bundler >10.1
Why:
Otherwise, build fails due to old warbler not being compatible with new bundler (bundler is not locked in version, since it is downloaded separately)

More:
See: https://github.com/bundler/bundler/issues/3691 and https://github.com/rubygems/rubygems/issues/505 for details.